### PR TITLE
extract method validate(JsonNode, String)

### DIFF
--- a/src/main/java/com/github/bjansen/ssv/SwaggerValidator.java
+++ b/src/main/java/com/github/bjansen/ssv/SwaggerValidator.java
@@ -96,12 +96,11 @@ public class SwaggerValidator {
     /**
      * Validates the given {@code jsonPayload} against the definition located at {@code definitionPointer}.
      *
-     * @param jsonPayload       the JSON payload to validate
+     * @param jsonPayload       the JSON payload (as a JsonNode) to validate
      * @param definitionPointer the path to the schema object the payload should be validated against,
      *                          for example {@code /definitions/User}
      * @return a validation report
      * @throws ProcessingException in case a processing error occurred during validation
-     * @throws IOException         if the payload is not a valid JSON object
      */
     public ProcessingReport validate(JsonNode jsonPayload, String definitionPointer) throws ProcessingException {
         return getSchema(definitionPointer).validate(jsonPayload);

--- a/src/main/java/com/github/bjansen/ssv/SwaggerValidator.java
+++ b/src/main/java/com/github/bjansen/ssv/SwaggerValidator.java
@@ -86,12 +86,25 @@ public class SwaggerValidator {
      */
     public ProcessingReport validate(String jsonPayload, String definitionPointer, ObjectMapper jsonMapper) throws ProcessingException, IOException {
         JsonNode jsonNode = jsonMapper.readTree(jsonPayload);
-
         if (jsonNode == null) {
             throw new IOException("The JSON payload could not be parsed correctly");
         }
 
-        return getSchema(definitionPointer).validate(jsonNode);
+        return validate(jsonNode, definitionPointer);
+    }
+
+    /**
+     * Validates the given {@code jsonPayload} against the definition located at {@code definitionPointer}.
+     *
+     * @param jsonPayload       the JSON payload to validate
+     * @param definitionPointer the path to the schema object the payload should be validated against,
+     *                          for example {@code /definitions/User}
+     * @return a validation report
+     * @throws ProcessingException in case a processing error occurred during validation
+     * @throws IOException         if the payload is not a valid JSON object
+     */
+    public ProcessingReport validate(JsonNode jsonPayload, String definitionPointer) throws ProcessingException {
+        return getSchema(definitionPointer).validate(jsonPayload);
     }
 
     /**


### PR DESCRIPTION
in order to be able to validate a JsonNode object instead of a String
when the json content has already been parsed as a JsonNode by the caller
